### PR TITLE
Re-target Rolling RPMs to RHEL 8

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -7,7 +7,7 @@ distributions:
       - steven+build.test.ros2.org@openrobotics.org
       - scott+build.test.ros2.org@openrobotics.org
     release_builds:
-      el: rolling/release-el-build.yaml
+      rhel: rolling/release-rhel-build.yaml
 doc_builds:
   ros2-documentation: ros2-documentation-build.yaml
 jenkins_url: https://build.test.ros2.org
@@ -109,5 +109,9 @@ status_page_repositories:
     - http://repo.test.ros2.org/ubuntu/building
     - http://repo.test.ros2.org/ubuntu/testing
     - http://repo.test.ros2.org/ubuntu/main
+  rhel:
+    - http://repo.test.ros2.org/rhel/building
+    - http://repo.test.ros2.org/rhel/testing
+    - http://repo.test.ros2.org/rhel/main
 type: buildfarm
 version: 1

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -47,7 +47,6 @@ package_blacklist:
 - teleop_tools  # Not yet generated for RHEL
 - teleop_tools_msgs  # Not yet generated for RHEL
 - test_osrf_testing_tools_cpp  # Doesn't install anything
-- tracetools  # Not yet generated for RHEL
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tracetools_launch  # Not yet generated for RHEL
 - tracetools_read  # Not yet generated for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -17,7 +17,7 @@ notifications:
 package_blacklist:
 - async_web_server_cpp  # Not yet generated for RHEL
 - autoware_auto_msgs  # Not yet generated for RHEL
-- bno055  # python3-serial has no RPM package for RHEL
+- bno055  # Not yet generated for RHEL
 - can_msgs  # Not yet generated for RHEL
 - canopen_402  # Not yet generated for RHEL
 - canopen_chain_node  # Not yet generated for RHEL
@@ -27,7 +27,7 @@ package_blacklist:
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 8
 - gazebo_dev  # Gazebo has no RPM package
 - grbl_msgs  # Not yet generated for RHEL
-- grbl_ros  # python3-serial has no RPM package for RHEL
+- grbl_ros  # Not yet generated for RHEL
 - joy_teleop  # Not yet generated for RHEL
 - key_teleop  # Not yet generated for RHEL
 - mouse_teleop  # Not yet generated for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -73,10 +73,25 @@ package_blacklist:
 - webots_ros2_universal_robot  # Not yet generated for RHEL
 - webots_ros2_ur_e_description  # Not yet generated for RHEL
 package_ignore_list:
-- rmw_connext  # No RPM package for Connext
-- rmw_gurumdds  # No RPM package for GurumDDS
-- rosidl_typesupport_connext  # No RPM package for Connext
-- rosidl_typesupport_gurumdds  # No RPM package for GurumDDS
+- connext_cmake_module  # No RPM package for Connext
+- demo_nodes_cpp_native_gurumdds  # No RPM package for GurumDDS
+- gurumdds_cmake_module  # No RPM package for GurumDDS
+- fastrtps  # RPM for asio is not yet available for RHEL 8
+- rmw_connext_cpp  # No RPM package for Connext
+- rmw_connext_dynamic_cpp  # No RPM package for Connext
+- rmw_connext_shared_cpp  # No RPM package for Connext
+- rmw_fastrtps_cpp  # RPM for asio is not yet available for RHEL 8
+- rmw_fastrtps_dynamic_cpp  # RPM for asio is not yet available for RHEL 8
+- rmw_fastrtps_shared_cpp  # RPM for asio is not yet available for RHEL 8
+- rmw_gurumdds_cpp  # No RPM package for GurumDDS
+- rmw_gurumdds_shared_cpp  # No RPM package for GurumDDS
+- rmw_gurumdds_static_cpp  # No RPM package for GurumDDS
+- rosidl_typesupport_connext_c  # No RPM package for Connext
+- rosidl_typesupport_connext_cpp  # No RPM package for Connext
+- rosidl_typesupport_fastrtps_c  # RPM for asio is not yet available for RHEL 8
+- rosidl_typesupport_fastrtps_cpp  # RPM for asio is not yet available for RHEL 8
+- rosidl_typesupport_gurumdds_c  # No RPM package for GurumDDS
+- rosidl_typesupport_gurumdds_cpp  # No RPM package for GurumDDS
 sync:
   package_count: 262
 repositories:

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -18,17 +18,16 @@ package_blacklist:
 - async_web_server_cpp  # Not yet generated for RHEL
 - autoware_auto_msgs  # Not yet generated for RHEL
 - bno055  # python3-serial has no RPM package for RHEL
-- can_msgs  # Not yet generated for RHE
-- canopen_402  # Not yet generated for RHE
-- canopen_chain_node  # Not yet generated for RHE
-- canopen_master  # Not yet generated for RHE
-- canopen_motor_node  # Not yet generated for RHE
-- cartographer  # Requires Lua v5.2, system packages v5.1
-- cv_bridge  # Requires OpenCV v3, system packages v2
+- can_msgs  # Not yet generated for RHEL
+- canopen_402  # Not yet generated for RHEL
+- canopen_chain_node  # Not yet generated for RHEL
+- canopen_master  # Not yet generated for RHEL
+- canopen_motor_node  # Not yet generated for RHEL
+- cartographer  # RPM for ceres-solver is not yet stable
+- control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 8
 - gazebo_dev  # Gazebo has no RPM package
 - grbl_msgs  # Not yet generated for RHEL
 - grbl_ros  # python3-serial has no RPM package for RHEL
-- image_tools  # Requires OpenCV v3, system packages v2
 - joy_teleop  # Not yet generated for RHEL
 - key_teleop  # Not yet generated for RHEL
 - mouse_teleop  # Not yet generated for RHEL
@@ -39,11 +38,11 @@ package_blacklist:
 - rc_genicam_driver  # Not yet generated for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - ros2trace  # Not yet generated for RHEL
-- ros_canopen  # Not yet generated for RHE
-- sdformat_urdf  # Requires sdformat v9, system packages v2
+- ros_canopen  # Not yet generated for RHEL
+- sdformat_urdf  # sdformat has no RPM packages for RHEL 8
 - serial_driver  # Not yet generated for RHEL
-- socketcan_bridge  # Not yet generated for RHE
-- socketcan_interface  # Not yet generated for RHE
+- socketcan_bridge  # Not yet generated for RHEL
+- socketcan_interface  # Not yet generated for RHEL
 - teleop_tools  # Not yet generated for RHEL
 - teleop_tools_msgs  # Not yet generated for RHEL
 - test_osrf_testing_tools_cpp  # Doesn't install anything
@@ -72,6 +71,11 @@ package_blacklist:
 - webots_ros2_tutorials  # Not yet generated for RHEL
 - webots_ros2_universal_robot  # Not yet generated for RHEL
 - webots_ros2_ur_e_description  # Not yet generated for RHEL
+package_ignore_list:
+- rmw_connext  # No RPM package for Connext
+- rmw_gurumdds  # No RPM package for GurumDDS
+- rosidl_typesupport_connext  # No RPM package for Connext
+- rosidl_typesupport_gurumdds  # No RPM package for GurumDDS
 sync:
   package_count: 262
 repositories:
@@ -130,12 +134,13 @@ repositories:
     =/1E+
     -----END PGP PUBLIC KEY BLOCK-----
   urls:
-  - http://repo.test.ros2.org/el/building/$releasever/$basearch/
-target_repository: http://repo.test.ros2.org/el/building
+  - http://repo.test.ros2.org/rhel/building/$releasever/$basearch/
+target_repository: http://repo.test.ros2.org/rhel/building
 targets:
   rhel:
-    '7':
+    '8':
       x86_64:
 type: release-build
 upload_credential_id: pulp_admin
+upload_dest_credential_id: pulp_base_url
 version: 2

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -158,5 +158,5 @@ targets:
       x86_64:
 type: release-build
 upload_credential_id: pulp_admin
-upload_dest_credential_id: pulp_base_url
+upload_destination_credential_id: pulp_base_url
 version: 2

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -37,10 +37,12 @@ package_blacklist:
 - rc_dynamics_api  # Not yet generated for RHEL
 - rc_genicam_api  # Not yet generated for RHEL
 - rc_genicam_driver  # Not yet generated for RHEL
+- rcl_logging_log4cxx  # RPM for log4cxx-devel is not yet stable
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - ros2trace  # Not yet generated for RHEL
 - ros_canopen  # Not yet generated for RHEL
 - rviz_assimp_vendor  # RPM for assimp is not yet stable
+- sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
 - serial_driver  # Not yet generated for RHEL
 - socketcan_bridge  # Not yet generated for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -39,6 +39,7 @@ package_blacklist:
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - ros2trace  # Not yet generated for RHEL
 - ros_canopen  # Not yet generated for RHEL
+- rviz_assimp_vendor  # RPM for assimp is not yet stable
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
 - serial_driver  # Not yet generated for RHEL
 - socketcan_bridge  # Not yet generated for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -15,6 +15,7 @@ notifications:
   - scott@openrobotics.org
   maintainers: false
 package_blacklist:
+- acado_vendor  # Not yet generated for RHEL
 - async_web_server_cpp  # Not yet generated for RHEL
 - autoware_auto_msgs  # Not yet generated for RHEL
 - bno055  # Not yet generated for RHEL


### PR DESCRIPTION
* Re-evaluate the package exclusion list
* Add list of packages to ignore
* Replace uses of `el` with `rhel`
* Add status a repo status page for RHEL
* Add the credential ID to use for the `PULP_BASE_URL`