### PR TITLE
[Staging]: Add melodic doc build

### DIFF
--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -1,0 +1,60 @@
+%YAML 1.1
+# ROS buildfarm doc-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 2
+canonical_base_url: http://docs.ros.org/en
+documentation_type: rosdoc_lite
+jenkins_job_priority: 85
+jenkins_job_timeout: 120
+notifications:
+  committers: false
+  emails:
+  - ros-buildfarm-melodic@googlegroups.com
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: true
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repositories.ros.org/ubuntu/testing
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: doc-build
+upload_credential_id: jenkins-agent
+upload_host: docs.ros.org
+upload_root: /var/www/docs.ros.org/en
+upload_user: rosbot
+version: 2

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -54,7 +54,7 @@ targets:
       amd64:
 type: doc-build
 upload_credential_id: jenkins-agent
-upload_host: docs.ros.org
+upload_host: bogus
 upload_root: /var/www/docs.ros.org/en
-upload_user: rosbot
+upload_user: bogus
 version: 2

--- a/melodic/doc-build.yaml
+++ b/melodic/doc-build.yaml
@@ -47,7 +47,7 @@ repositories:
     =4Ofr
     -----END PGP PUBLIC KEY BLOCK-----
   urls:
-  - http://repositories.ros.org/ubuntu/testing
+  - http://packages.ros.org/ros-testing/ubuntu
 targets:
   ubuntu:
     bionic:


### PR DESCRIPTION
This PR enables melodic doc jobs on the staging farm.  This is only to do some debugging; once I'm finished with the debugging, I'd remove this configuration and the jobs.  Also, I think this is the command I would run to get the debugging I want done:

```
./scripts/doc/generate_doc_job.py https://raw.githubusercontent.com/ros-staging/ros_buildfarm_config/staging/index.yaml melodic default capabilities ubuntu bionic amd64
```

(that is, generate the docjob for the "capabilities" package on Ubuntu Bionic amd64, which should generate a job similar to https://build.ros.org/view/Mdoc/job/Mdoc__capabilities__ubuntu_bionic_amd64/)